### PR TITLE
Use Compose for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.DEFAULT_GOAL=up
+
+.PHONY: build
+build:
+	docker compose build
+
+.PHONY: build-ui
+build-ui:
+	docker compose build ui
+
+.PHONY: build-api
+build-api:
+	docker compose build api
+
+.PHONY: up
+up: build
+	docker compose up
+
+.PHONY: up-ui
+up-ui: build-ui
+	docker compose up ui
+
+.PHONY: up-api
+up-api: build-api
+	docker compose up api

--- a/Makefile
+++ b/Makefile
@@ -4,22 +4,22 @@
 build:
 	docker compose build
 
-.PHONY: build-ui
-build-ui:
-	docker compose build ui
+.PHONY: build-frontend
+build-frontend:
+	docker compose build frontend
 
-.PHONY: build-api
-build-api:
-	docker compose build api
+.PHONY: build-backend
+build-backend:
+	docker compose build backend
 
 .PHONY: up
 up: build
 	docker compose up
 
-.PHONY: up-ui
-up-ui: build-ui
-	docker compose up ui
+.PHONY: up-frontend
+up-frontend: build-frontend
+	docker compose up frontend
 
-.PHONY: up-api
-up-api: build-api
-	docker compose up api
+.PHONY: up-backend
+up-backend: build-backend
+	docker compose up backend

--- a/README.md
+++ b/README.md
@@ -1,44 +1,45 @@
-# Infrastructure Engineer 3 Take-Home Assessment
+# Taskly
 
-This is the repository for the System Initiative Infrastructure Engineer III take-home assessment. It is designed to verify that:
+Taskly is an application that allows users to sign in and create tasks. It is
+also used by [System Initiative](https://www.systeminit.com/) as an
+[assessment](https://github.com/systeminit/assessment-ie3) for their
+Infrastructure Engineer III role.
 
-* You have proficiency in designing and implementing CI/CD pipelines
-* You have proficiency in deploying a containerized application
+## Development
 
-We use a take-home assessment so that you can have your most productive environment at hand. Use whatever editor, operating system, etc. you like. Google to your heart's content. 
+Taskly is split into two components, a `frontend` and a `backend`. These
+components can be run locally using either Docker or npm, each of which support
+hot-reloading for a fast development feedback cycle. For more information about
+each component, refer to its `README.md` in its respective directory.
 
-Please spend no more than 4 hours on this assessment. 
+### Using Docker
 
-## What you'll be doing
+Start both the frontend and backend.
 
-We created a fake company called Taskly, and you’ve been hired as the first Infrastructure Engineer! Taskly is a new company that’s reinventing the task list, and the engineering team has been busy working toward a beta-launch. They’re ready to get this product into the world and start getting feedback! We want you to build a CI/CD pipeline that deploys Taskly into a cloud environment.  
+```sh
+make
+```
 
-Taskly is split into two components - a `frontend` and a `backend`. Each component has its own README with information about the components, including full instructions on how to run it (including link checks and automated tests).
+Access Taskly using the following URLs.
 
-To get started, [fork this repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo). If you prefer, you can make your fork private and add `britmyerss`,
-`fnichol`, `stack72`, and `mahirl` as collaborators. When you've finished, let us know
-via email, with a link to your fork. We'll review it and get back to you!
+- Frontend - http://localhost:3000
+- Backend - http://localhost:3030
 
-Have fun!
+### Using npm
 
+Open a separate terminal and run the frontend.
 
-## How you'll be building it
+```sh
+cd frontend && npm install && npm run dev
+```
 
-Your implementation should, at minimum, include: 
+Open a separate terminal and run the backend.
 
-* running lint checks
-* tests
-* building each component as a container image
-* running those containers in the cloud
+```sh
+cd backend && npm install && npm run dev
+```
 
-We want you to use whatever tools and cloud provider you’re most comfortable with. However, please stick to the free tiers or use mock APIs, as we don’t want you paying anything out of pocket for this! 
+Access Taskly using the following URLs.
 
-We also want you to include a README, that tells us how you’ve designed your solution and how it works. 
-
-Upon completion, we will fork your repo, open a pull request, and see your pipeline in action! 
-
-
-# Good luck!
-
-Thank you so much for taking the time to do the assessment. We're looking forward
-to reviewing your work!
+- Frontend - http://localhost:3000
+- Backend - http://localhost:3030

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+README.md
+dist
+node_modules

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:20.4.0
-WORKDIR /taskly-api
+WORKDIR /taskly-backend
 COPY package.json ./package.json
 COPY package-lock.json ./package-lock.json
 RUN npm clean-install

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20.4.0
+WORKDIR /taskly-api
+COPY package.json ./package.json
+COPY package-lock.json ./package-lock.json
+RUN npm clean-install
+COPY . .
+RUN npm run build

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tasky-backend",
+  "name": "taskly-backend",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "tasky-backend",
+      "name": "taskly-backend",
       "version": "1.0.0",
       "license": "Apache 2",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tasky-backend",
+  "name": "taskly-backend",
   "version": "1.0.0",
-  "description": "A backend for tasky!",
+  "description": "A backend for taskly!",
   "main": "src/index.js",
   "scripts": {
     "build": "tsc",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,5 +2,5 @@
 import { app } from "./app";
 
 // Start the application listening on port 3030.
-console.log("Starting tasky backend on http://0.0.0.0:3030");
+console.log("Starting taskly backend on http://0.0.0.0:3030");
 app.listen(3030);

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,25 +1,25 @@
 ---
 name: taskly
 services:
-  ui:
+  frontend:
     build:
       context: ./frontend
     command: ["npm", "run", "dev"]
     environment:
-      TASKLY_API_URL: "http://api:3030"
+      TASKLY_API_URL: "http://backend:3030"
     volumes:
       - type: bind
         source: ./frontend/src
-        target: /taskly-ui/src
+        target: /taskly-frontend/src
     ports:
       - "3000:3000"
-  api:
+  backend:
     build:
       context: ./backend
     command: ["npm", "run", "dev"]
     volumes:
       - type: bind
         source: ./backend/src
-        target: /taskly-api/src
+        target: /taskly-backend/src
     ports:
       - "3030:3030"

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,9 +5,21 @@ services:
     build:
       context: ./frontend
     command: ["npm", "run", "dev"]
+    environment:
+      TASKLY_API_URL: "http://api:3030"
     volumes:
       - type: bind
         source: ./frontend/src
         target: /taskly-ui/src
     ports:
       - "3000:3000"
+  api:
+    build:
+      context: ./backend
+    command: ["npm", "run", "dev"]
+    volumes:
+      - type: bind
+        source: ./backend/src
+        target: /taskly-api/src
+    ports:
+      - "3030:3030"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,13 @@
+---
+name: taskly
+services:
+  ui:
+    build:
+      context: ./frontend
+    command: ["npm", "run", "dev"]
+    volumes:
+      - type: bind
+        source: ./frontend/src
+        target: /taskly-ui/src
+    ports:
+      - "3000:3000"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+README.md
+dist
+node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20.4.0
+WORKDIR /taskly-ui
+COPY package.json ./package.json
+COPY package-lock.json ./package-lock.json
+RUN npm clean-install
+COPY . .
+RUN npm run build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:20.4.0
-WORKDIR /taskly-ui
+WORKDIR /taskly-frontend
 COPY package.json ./package.json
 COPY package-lock.json ./package-lock.json
 RUN npm clean-install

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "tasky",
-  "version": "0.0.0",
+  "name": "taskly-frontend",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "tasky",
-      "version": "0.0.0",
+      "name": "taskly-frontend",
+      "version": "1.0.0",
       "dependencies": {
         "@headlessui/vue": "^1.6.4",
         "@heroicons/vue": "^1.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "tasky",
-  "version": "0.0.0",
+  "name": "taskly-frontend",
+  "version": "1.0.0",
+  "description": "A frontend for taskly!",
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "run-p type-check build-only",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "tasky",
   "version": "0.0.0",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0",
     "build": "run-p type-check build-only",
     "preview": "vite preview --port 4173",
     "build-only": "vite build",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      "/api": "http://localhost:3030",
+      "/api": process.env.TASKLY_API_URL || "http://localhost:3030",
     },
   },
 });


### PR DESCRIPTION
This pull request creates a local development environment for Taskly using Compose.

The major changes include `Dockerfile`s for both the `frontend` and `backend` components, a `compose.yaml` to run Taskly locally using Compose, and a `Makefile` to wrap some of the common Compose commands for ease of use. The source code for both the `frontend` and `backend` components is bind mounted into the containers to allow hot-reloading during local development.

I made the following two changes to the frontend component so that I could connect to the frontend and so the frontend could connect to the backend.

- Configured `vite` to listen on `0.0.0.0` so that I could connect to the frontend when it was running inside a container.
- Introduced the `TASKLY_API_URL` environment variable to tell the frontend where the backend API is. The frontend was unconditionally using `http://localhost:3030` as the backend API URL which doesn't work when the frontend and backend are in separate containers.

During local development I noticed that there was a typo in the code where `taskly` was mistakenly being typed as `tasky`. I fixed that while I was in the code.
