### PR TITLE
Implement health API endpoint

### DIFF
--- a/backend/src/handlers/health.ts
+++ b/backend/src/handlers/health.ts
@@ -1,0 +1,10 @@
+// The REST handlers for health.
+
+import { Context, Next } from "koa";
+
+// Health check endpoint used to determine if the API is up.
+export const health = async (ctx: Context, next: Next) => {
+    ctx.body = { status: "healthy" };
+    ctx.status = 200;
+    await next();
+};

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -4,9 +4,11 @@
 import * as Router from "@koa/router";
 import { createUser, listUsers } from "./handlers/users";
 import { createTask, listTasks } from "./handlers/tasks";
+import { health } from "./handlers/health";
 
 export const router = new Router();
 router.get("/api/users", listUsers);
 router.post("/api/users", createUser);
 router.post("/api/tasks", createTask);
 router.get("/api/tasks/:userId", listTasks);
+router.get("/api/health", health);

--- a/backend/tests/handlers/health.spec.ts
+++ b/backend/tests/handlers/health.spec.ts
@@ -1,0 +1,13 @@
+// Tests for our health API.
+
+import * as request from "supertest";
+import { app } from "../../src/app";
+
+test("health", async () => {
+    const res = await request(app.callback())
+        .get("/api/health")
+        .send()
+        .expect(200);
+    expect(res.body).not.toBeNull();
+    expect(res.body).toEqual(expect.objectContaining({ status: "healthy" }));
+});


### PR DESCRIPTION
This pull request implements a health API endpoint that we can use to determine if the backend API is up and healthy rather than hitting an existing route such as `/api/users` which would normally make a round trip request to a database.