### PR TITLE
Use multi-stage container images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,10 +41,11 @@ jobs:
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build Container
+      - name: Build Container Image
         uses: docker/build-push-action@v4
         with:
           context: ./frontend
+          target: production
           load: true
           tags: sudomateo/taskly-frontend:${{ github.sha }}
       - name: Run Trivy Scanner
@@ -55,6 +56,14 @@ jobs:
           exit-code: "1"
           vuln-type: "os"
           ignore-unfixed: true
+      - name: Push Container Image
+        if: ${{ github.ref_name == 'main' }}
+        uses: docker/build-push-action@v4
+        with:
+          context: ./frontend
+          target: production
+          push: true
+          tags: sudomateo/taskly-frontend:${{ github.sha }}
 
   lint-backend:
     name: Lint Backend
@@ -107,10 +116,11 @@ jobs:
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build Container
+      - name: Build Container Image
         uses: docker/build-push-action@v4
         with:
           context: ./backend
+          target: production
           load: true
           tags: sudomateo/taskly-backend:${{ github.sha }}
       - name: Run Trivy Scanner
@@ -121,3 +131,11 @@ jobs:
           exit-code: "1"
           vuln-type: "os"
           ignore-unfixed: true
+      - name: Push Container Image
+        if: ${{ github.ref_name == 'main' }}
+        uses: docker/build-push-action@v4
+        with:
+          context: ./backend
+          target: production
+          push: true
+          tags: sudomateo/taskly-backend:${{ github.sha }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,21 @@
-FROM node:20.4.0
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+ARG NODE_VERSION=20.4.0
+
+FROM node:${NODE_VERSION} AS base
 WORKDIR /taskly-backend
 COPY package.json ./package.json
 COPY package-lock.json ./package-lock.json
 RUN npm clean-install
 COPY . .
 RUN npm run build
+
+FROM node:${NODE_VERSION} AS production
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /taskly-backend
+COPY --from=base /taskly-backend/package.json ./package.json
+COPY --from=base /taskly-backend/package-lock.json ./package-lock.json
+COPY --from=base /taskly-backend/dist ./dist
+RUN npm clean-install --omit=dev
+CMD ["npm", "run", "start"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "nodemon --watch './src/**/*.ts' --exec 'ts-node' ./src/index.ts",
-    "start": "tsc && node ./dist/index.js",
+    "start": "node ./dist/index.js",
     "lint": "eslint --ext .ts ./src",
     "lint:fix": "eslint --fix --ext .ts ./src",
     "format": "prettier --ignore-path .gitignore --write \"src/**/*.ts\"",

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,7 @@ services:
   frontend:
     build:
       context: ./frontend
+      target: base
     command: ["npm", "run", "dev"]
     environment:
       TASKLY_API_URL: "http://backend:3030"
@@ -16,6 +17,7 @@ services:
   backend:
     build:
       context: ./backend
+      target: base
     command: ["npm", "run", "dev"]
     volumes:
       - type: bind

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,12 @@
-FROM node:20.4.0
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+ARG NODE_VERSION=20.4.0
+
+FROM node:${NODE_VERSION} AS base
 WORKDIR /taskly-frontend
 COPY package.json ./package.json
 COPY package-lock.json ./package-lock.json
 RUN npm clean-install
 COPY . .
 RUN npm run build
+
+FROM nginx:1.25.1 AS production
+COPY --from=base /taskly-frontend/dist /usr/share/nginx/html


### PR DESCRIPTION
This pull requests updates the container images for both the `frontend` and `backend` components to use multi-state container images. It also updates the GitHub Actions to push the container images on merge to `main`.

This allows us to introduce a production image that is smaller, more secure, and more performant. The production image of the `frontend` component uses the production `vite` build and is served as static files using Nginx. The production image of the `backend` component no longer includes the source code or the development dependencies.

The image size for the `frontend` component has been reduced significantly.

Before this pull request:

```sh
> docker image ls
REPOSITORY        TAG       IMAGE ID       CREATED         SIZE
taskly-backend    latest    e99de61c99f2   9 minutes ago   1.27GB
taskly-frontend   latest    0c5d78c1103c   9 minutes ago   1.3GB
```

After this pull request:

```sh
> docker image ls
REPOSITORY        TAG       IMAGE ID       CREATED          SIZE
taskly-backend    latest    debcab94159b   14 seconds ago   1.11GB
taskly-frontend   latest    8255ac669fe2   14 seconds ago   187MB
```