### PR TITLE
Introduce deployment job for Taskly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,3 +139,28 @@ jobs:
           target: production
           push: true
           tags: sudomateo/taskly-backend:${{ github.sha }}
+
+  deploy:
+    name: Deploy Taskly
+    if: ${{ github.ref_name == 'main' }}
+    needs: ["build-frontend", "build-backend"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.3
+          cli_config_credentials_token: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
+          terraform_wrapper: false
+      - name: Terraform Init
+        run: terraform init
+        working-directory: infrastructure
+      - name: Terraform Apply
+        env:
+          DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
+          TF_VAR_frontend_tag: ${{ github.sha }}
+          TF_VAR_backend_tag: ${{ github.sha }}
+        run: terraform apply -auto-approve
+        working-directory: infrastructure

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Terraform data directories.
+.terraform/
+
+# Terraform state files.
+*.tfstate
+*.tfstate.*
+
+# Terraform variable files.
+*.tfvars
+*.tfvars.json
+
+# Terraform CLI configuration files.
+.terraformrc
+terraform.rc
+
+# Terraform override files.
+*_override.tf
+*_override.tf.json
+override.tf
+override.tf.json
+
+# Terraform crash logs.
+crash.*.log
+crash.log

--- a/infrastructure/.terraform.lock.hcl
+++ b/infrastructure/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/digitalocean/digitalocean" {
+  version     = "2.28.1"
+  constraints = "2.28.1"
+  hashes = [
+    "h1:aSxcSWa0wQQGLW2/XyivecmR/BL9fVtw42Bg2UngmT0=",
+    "zh:2e22294110ddfc4cd8c51e342f56788175d02b2bb311f1834f3c144a80dc30dc",
+    "zh:59641f0c7b10befced370008a3178670ee1103fcb504a9b71f90d6f697738fc2",
+    "zh:5d4c48701dbf3316cc149a01e44bed8cacb4426d4981a415ca1149a26af608af",
+    "zh:5fc27f1948669378d5f1d0cd0352fed92a3516738cb4bdeff026ea9242e364b0",
+    "zh:673bb803646c359809db39ccead45c1ea5ab12b47dd4dd14a576fe5c6300e386",
+    "zh:67e212f02ac0acdfc9d448299acefc3e4ea6aaad9a229f7f97e9064e1512a33f",
+    "zh:6dcd108fb68ce1b1cbfe9d4c4df0f0f4c3c09bd6154724df9bd33e1630cd6e0b",
+    "zh:757e4b2f3c728a6b781521e8f7e47ed8bd7bf189f5e273d953a0d849463d9af5",
+    "zh:7ae1a6cb34c45a00f84090ad2dcc7eac23fd748a026801bfe19e60a96893882f",
+    "zh:7fecfea5b2b2e79ee1c49b824995ed5232e7f538fdfe33aa984a1bda90bf1587",
+    "zh:8e5671bd7cbc2e45e3e9e4ec803e8d9b671f687c66963f52bf1bf58cb7b05819",
+    "zh:a6a5b504c95eff173e2ac017523a97e3300d93fa887465b0278c2633dd0cc608",
+    "zh:cd273e7c690e6758761f583a35f76d0e86259ccc842be137931e4cf9d8c3d1cc",
+    "zh:e815c665ed5c32057d1f4dc0288b6387ba38b2a5bf5ef0c36987810a141d3b39",
+    "zh:ebac3d11f2e968f88f95e3f277b547f505ecd7150df0fd763087499b251bca9e",
+    "zh:fb970aa84783edc03ea4ec53d2b896721fbab08b4b764a284e3d7eb49bfa046e",
+  ]
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,0 +1,85 @@
+terraform {
+  cloud {
+    organization = "sudomateo"
+
+    workspaces {
+      name = "taskly"
+    }
+  }
+
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "2.28.1"
+    }
+  }
+}
+
+provider "digitalocean" {}
+
+variable "frontend_tag" {
+  type        = string
+  description = "Container image tag of the frontend image."
+}
+
+variable "backend_tag" {
+  type        = string
+  description = "Container image tag of the backend image."
+}
+
+resource "digitalocean_app" "taskly" {
+  spec {
+    name   = "taskly"
+    region = "nyc3"
+
+    service {
+      name = "frontend"
+
+      instance_count = 1
+      http_port      = 80
+
+      image {
+        registry_type = "DOCKER_HUB"
+        registry      = "sudomateo"
+        repository    = "taskly-frontend"
+        tag           = var.frontend_tag
+      }
+
+      routes {
+        path                 = "/"
+        preserve_path_prefix = true
+      }
+
+      health_check {
+        http_path = "/"
+      }
+    }
+
+    service {
+      name = "backend"
+
+      instance_count = 1
+      http_port      = 3030
+
+      image {
+        registry_type = "DOCKER_HUB"
+        registry      = "sudomateo"
+        repository    = "taskly-backend"
+        tag           = var.backend_tag
+      }
+
+      routes {
+        path                 = "/api"
+        preserve_path_prefix = true
+      }
+
+      health_check {
+        http_path = "/api/health"
+      }
+    }
+  }
+}
+
+output "url" {
+  value = digitalocean_app.taskly.live_url
+}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions job to deploy Taskly using DigitalOcean's App Platform. The deployment will only trigger on merge to `main`, using the latest commit from `main` as the image for both components.

On merge to `main` the `frontend` and `backend` components are linted, tested, and their container images are built and pushed to Docker Hub. After the container images are pushed to Docker Hub, Terraform is executed to deploy Taskly to DigitalOcean App Platform.

This is the architecture diagram for Taskly running on DigitalOcean App Platform.

```mermaid
flowchart LR
    subgraph app [DigitalOcean App Platform]
        ingress[Ingress]

        subgraph components [Components]
            frontend[Frontend]
            backend[Backend]
        end

        ingress-->|/|frontend
        ingress-->|/api|backend
    end

    client[Client]
    client-->ingress
```